### PR TITLE
Add container to prevent horizontal scroll

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -3,6 +3,7 @@
 @{
     ViewData["Title"] = "Home page";
 }
+<div class="container-fluid">
     <div class="row">
         @if (!User.Identity.IsAuthenticated)
         {
@@ -69,3 +70,4 @@
             }
         }
     </div>
+</div>


### PR DESCRIPTION
In Bootstrap, the `.row` class is meant to be used inside a `.container-*` due to their padding gutter system. Without a container, it becomes oversized and causes undesired horizontal scroll.